### PR TITLE
[codex] Add Spark Name v2 registration payload support

### DIFF
--- a/src/sparkname.h
+++ b/src/sparkname.h
@@ -48,6 +48,8 @@ public:
         if (nVersion == 2)
         {
             READWRITE(operationType);
+            if (operationType != 0)
+                throw std::ios_base::failure("Unsupported Spark Name operation type");
         }
     }
 };

--- a/src/sparkname.h
+++ b/src/sparkname.h
@@ -9,7 +9,7 @@ namespace spark {
 struct CSparkNameTxData
 {
 public:
-    static const uint16_t CURRENT_VERSION = 1;
+    static const uint16_t CURRENT_VERSION = 2;
 
 public:
     uint16_t nVersion{CURRENT_VERSION};     // version
@@ -27,6 +27,8 @@ public:
     std::string additionalInfo;
     // failsafe if the hash of the transaction data is can't be converted to a scalar for proof creation/verification
     uint32_t hashFailsafe{0};
+    // Registration-only; add transfer fields if mobile starts creating Spark Name transfers.
+    uint8_t operationType{0};
 
     ADD_SERIALIZE_METHODS;
 
@@ -41,6 +43,10 @@ public:
         READWRITE(sparkNameValidityBlocks);
         READWRITE(additionalInfo);
         READWRITE(hashFailsafe);
+        if (nVersion >= 2)
+        {
+            READWRITE(operationType);
+        }
     }
 };
 

--- a/src/sparkname.h
+++ b/src/sparkname.h
@@ -36,6 +36,8 @@ public:
     void SerializationOp(Stream &s, Operation ser_action)
     {
         READWRITE(nVersion);
+        if (nVersion != 1 && nVersion != 2)
+            throw std::ios_base::failure("Unsupported Spark Name transaction data version");
         READWRITE(inputsHash);
         READWRITE(name);
         READWRITE(sparkAddress);
@@ -43,7 +45,7 @@ public:
         READWRITE(sparkNameValidityBlocks);
         READWRITE(additionalInfo);
         READWRITE(hashFailsafe);
-        if (nVersion >= 2)
+        if (nVersion == 2)
         {
             READWRITE(operationType);
         }

--- a/tests/spark_name_test.cpp
+++ b/tests/spark_name_test.cpp
@@ -42,6 +42,8 @@ BOOST_AUTO_TEST_CASE(spark_names)
     BOOST_CHECK_EQUAL(decodedData.sparkAddress, sparkNameData.sparkAddress);
     BOOST_CHECK_EQUAL(decodedData.sparkNameValidityBlocks, sparkNameData.sparkNameValidityBlocks);
     BOOST_CHECK_EQUAL(decodedData.additionalInfo, sparkNameData.additionalInfo);
+    BOOST_CHECK_EQUAL(decodedData.nVersion, spark::CSparkNameTxData::CURRENT_VERSION);
+    BOOST_CHECK_EQUAL((int)decodedData.operationType, 0);
     BOOST_CHECK(!decodedData.addressOwnershipProof.empty());
 
     spark::OwnershipProof deserializedOwnershipProof;

--- a/tests/spark_name_test.cpp
+++ b/tests/spark_name_test.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(rejects_unsupported_spark_name_data)
     data.operationType = 0;
     CDataStream encodedOperation(SER_NETWORK, PROTOCOL_VERSION);
     encodedOperation << data;
-    encodedOperation.back() = 1;
+    encodedOperation[encodedOperation.size() - 1] = 1;
     BOOST_CHECK_THROW(encodedOperation >> data, std::ios_base::failure);
 }
 

--- a/tests/spark_name_test.cpp
+++ b/tests/spark_name_test.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(spark_names)
     BOOST_CHECK(address.verify_own(m, deserializedOwnershipProof));
 }
 
-BOOST_AUTO_TEST_CASE(rejects_unsupported_spark_name_versions)
+BOOST_AUTO_TEST_CASE(rejects_unsupported_spark_name_data)
 {
     spark::CSparkNameTxData data;
     data.nVersion = 3;
@@ -69,6 +69,17 @@ BOOST_AUTO_TEST_CASE(rejects_unsupported_spark_name_versions)
     encodedData[0] = 3;
     encodedData[1] = 0;
     BOOST_CHECK_THROW(encodedData >> data, std::ios_base::failure);
+
+    data.nVersion = 2;
+    data.operationType = 1;
+    CDataStream unsupportedOperation(SER_NETWORK, PROTOCOL_VERSION);
+    BOOST_CHECK_THROW(unsupportedOperation << data, std::ios_base::failure);
+
+    data.operationType = 0;
+    CDataStream encodedOperation(SER_NETWORK, PROTOCOL_VERSION);
+    encodedOperation << data;
+    encodedOperation.back() = 1;
+    BOOST_CHECK_THROW(encodedOperation >> data, std::ios_base::failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/spark_name_test.cpp
+++ b/tests/spark_name_test.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(spark_names)
     BOOST_CHECK_EQUAL(decodedData.sparkAddress, sparkNameData.sparkAddress);
     BOOST_CHECK_EQUAL(decodedData.sparkNameValidityBlocks, sparkNameData.sparkNameValidityBlocks);
     BOOST_CHECK_EQUAL(decodedData.additionalInfo, sparkNameData.additionalInfo);
-    BOOST_CHECK_EQUAL(decodedData.nVersion, spark::CSparkNameTxData::CURRENT_VERSION);
+    BOOST_CHECK_EQUAL(decodedData.nVersion, uint16_t{2});
     BOOST_CHECK_EQUAL((int)decodedData.operationType, 0);
     BOOST_CHECK(!decodedData.addressOwnershipProof.empty());
 

--- a/tests/spark_name_test.cpp
+++ b/tests/spark_name_test.cpp
@@ -56,4 +56,17 @@ BOOST_AUTO_TEST_CASE(spark_names)
     BOOST_CHECK(address.verify_own(m, deserializedOwnershipProof));
 }
 
+BOOST_AUTO_TEST_CASE(rejects_unsupported_spark_name_versions)
+{
+    spark::CSparkNameTxData data;
+    data.nVersion = 3;
+    CDataStream serialized(SER_NETWORK, PROTOCOL_VERSION);
+    BOOST_CHECK_THROW(serialized << data, std::ios_base::failure);
+
+    uint16_t unsupportedVersion = 3;
+    CDataStream encodedVersion(SER_NETWORK, PROTOCOL_VERSION);
+    encodedVersion << unsupportedVersion;
+    BOOST_CHECK_THROW(encodedVersion >> data, std::ios_base::failure);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/spark_name_test.cpp
+++ b/tests/spark_name_test.cpp
@@ -63,10 +63,12 @@ BOOST_AUTO_TEST_CASE(rejects_unsupported_spark_name_versions)
     CDataStream serialized(SER_NETWORK, PROTOCOL_VERSION);
     BOOST_CHECK_THROW(serialized << data, std::ios_base::failure);
 
-    uint16_t unsupportedVersion = 3;
-    CDataStream encodedVersion(SER_NETWORK, PROTOCOL_VERSION);
-    encodedVersion << unsupportedVersion;
-    BOOST_CHECK_THROW(encodedVersion >> data, std::ios_base::failure);
+    data.nVersion = 2;
+    CDataStream encodedData(SER_NETWORK, PROTOCOL_VERSION);
+    encodedData << data;
+    encodedData[0] = 3;
+    encodedData[1] = 0;
+    BOOST_CHECK_THROW(encodedData >> data, std::ios_base::failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What changed

- Bumps `CSparkNameTxData::CURRENT_VERSION` from 1 to 2.
- Adds the v2 `operationType` byte, defaulting to registration (`0`).
- Rejects transaction-data versions other than the explicitly supported v1 and v2 layouts.
- Extends the Spark Name tests to cover v2 serialization and unsupported-version rejection.
- Avoids ODR-using the header-only `CURRENT_VERSION` constant in that test.

## Why / scope

This aligns Spark Mobile with the existing Spark Name v2 payload format. The `operationType` field predates the recent v2.1 hard fork and is not the fix for registrations remaining unconfirmed; Firo Core still accepts v1 registration payloads after v2 activation.

The recent v2.1 requirement relevant to the failure is a tagged registration-fee output. The caller constructs that output and must include its extra bytes in the miner-fee estimate, so the confirmation fix is in Stack Wallet PR #1413.

The mobile serializer has no later consensus-validation step, so accepting every `nVersion >= 2` could silently encode or decode an unknown future layout as v2. It now fails immediately unless the version is exactly 1 or 2.

## Related

- Flutter wrapper PR: https://github.com/firoorg/flutter_libsparkmobile/pull/1
- Stack Wallet v2.1 fee fix: https://github.com/cypherstack/stack_wallet/pull/1413

## Review notes

This intentionally remains registration-only. Transfer fields can be added if mobile begins creating Spark Name transfers.

## Validation

- `git diff --check` passes locally, with only Windows CRLF warnings.
- Both modified Boost test sources compile successfully.
- A standalone check confirms version 3 throws during both serialization and deserialization.
- The same Spark Name source compiled successfully through `firoorg/flutter_libsparkmobile`'s Windows CMake build and linked `libflutter_libsparkmobile.dll`.
- The standalone `spark_name_tests` build remains blocked in the available Windows environment by its existing POSIX `endian.h` assumption; no build-system workaround is included in this PR.