### PR TITLE
Fix secp256k1 scratch compilation on Windows

### DIFF
--- a/secp256k1/src/ecmult_impl.h
+++ b/secp256k1/src/ecmult_impl.h
@@ -12,6 +12,7 @@
 #include "group.h"
 #include "scalar.h"
 #include "ecmult.h"
+#include "scratch_impl.h"
 
 #if defined(EXHAUSTIVE_TEST_ORDER)
 /* We need to lower these values for exhaustive tests because

--- a/secp256k1/src/secp256k1.c
+++ b/secp256k1/src/secp256k1.c
@@ -17,6 +17,7 @@
 #include "ecdsa_impl.h"
 #include "eckey_impl.h"
 #include "hash_impl.h"
+#include "scratch_impl.h"
 
 #define ARG_CHECK(cond) do { \
     if (EXPECT(!(cond), 0)) { \

--- a/secp256k1/src/secp256k1.c
+++ b/secp256k1/src/secp256k1.c
@@ -17,7 +17,6 @@
 #include "ecdsa_impl.h"
 #include "eckey_impl.h"
 #include "hash_impl.h"
-#include "scratch_impl.h"
 
 #define ARG_CHECK(cond) do { \
     if (EXPECT(!(cond), 0)) { \


### PR DESCRIPTION
## Summary

Include `scratch_impl.h` from `ecmult_impl.h`.

## Why

The scratch helpers are declared `static`, so every translation unit that includes and uses `ecmult_impl.h` needs their definitions in that same translation unit. Without them, MSVC reports C2129 errors.

Putting the implementation include at the dependency boundary covers `secp256k1.c`, `GroupElement.cpp`, `MultiExponent.cpp`, and other direct users without platform conditionals or linkage changes. This is the minimal alternative to #8.

## Impact

The change is one internal include. Scratch helpers retain internal linkage, public headers and ABI are unchanged, and non-Windows builds keep the same behavior.

## Validation

- MinGW-w64 GCC/G++ compiled `secp256k1.c`, `GroupElement.cpp`, `MultiExponent.cpp`, `Scalar.cpp`, and a smoke-test source.
- All compiled objects had zero undefined `secp256k1_scratch_*` symbols.
- The full smoke executable linked successfully with the project's crypto/system libraries.
- Runtime smoke test covered context creation/destruction and a one-point `MultiExponent` calculation; exit code 0.